### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=This library makes it easy to build rich application REST servers that
 category=Communication
 url=https://github.com/sidoh/rich_http_server
 architectures=esp8266,esp32
+depends=ArduinoJson, PathVariableHandlers


### PR DESCRIPTION
Specifying the library dependencies in the depends field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library. "arduino-cli lib install" will automatically install the dependencies (arduino-cli 0.7.0 and newer).